### PR TITLE
Avoid error for empty response bodies with 'json' response type

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -138,7 +138,12 @@ export const request = async (options: HttpOptions): Promise<HttpResponse> => {
       data = await readBlobAsBase64(blob);
       break;
     case 'json':
-      data = await response.json();
+      const responseText = await response.text();
+      try {
+        data = responseText !== '' ? JSON.parse(responseText) : null;
+      } catch {
+        data = responseText;
+      }
       break;
     case 'document':
     case 'text':


### PR DESCRIPTION
-response.json() throws an error if the response doesn't contain valid JSON
-Use the original unparsed response if it's not valid JSON